### PR TITLE
(feature) implement confirmation toggling power for driver profile

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -70,7 +70,13 @@ module.exports = {
       }, req.query)
     },
     post: function (req, res) {},
-    put: function(callback, data) {}
+    put: function(req, res) {
+      console.log('inside controllers driverConfirmed put');
+      console.log("Here's the body", req.body);
+      models.driverConfirmed.put(function(newRole){
+        res.send({"newRole": newRole});
+      }, req.body);
+    }
   },
   driverUnconfirmed:{
     get: function (req, res) {
@@ -83,7 +89,12 @@ module.exports = {
       }, req.query)
     },
     post: function (req, res) {},
-    put: function(callback, data) {}
+    put: function(req, res) {
+      console.log('inside controllers driverConfirmed put');
+      models.driverConfirmed.put(function(record){
+        res.send({"updated": record});
+      }, req.body);
+    }
   },
   eventRider: {
     get: function (req, res) {

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -2,6 +2,7 @@ var db = require("../db/db.js");
 var serverHelpers = require("../server-helpers");
 var bcrypt = require('bcrypt');
 var _ = require('lodash');
+var utils = require('../server-helpers');
 //Someday, everything will break because I've confused camelCase
 //with under_scores. You have been warned.
 
@@ -82,9 +83,7 @@ module.exports = models = {
         })
       })
     },
-    put: function(callback, data) {
-      //THIS IS WHERE WE BEGIN AGAIN
-    },
+    put: utils.toggleConfirm,
     post: function(){}
   },
 
@@ -105,8 +104,8 @@ module.exports = models = {
         })
       })
     },
-    post: function(){},
-    put: function(callback, data) {}
+    put: utils.toggleConfirm,
+    post: function(){}
   },
 
 

--- a/server/server-helpers/index.js
+++ b/server/server-helpers/index.js
@@ -29,3 +29,21 @@ exports.riderUnconfirmedFormat = function(riderInfo, driverInfo) {
   });
   return riderUnconfirmedArr;
 }
+
+exports.toggleConfirm = function(callback, data) {
+  db.sequelize.query(
+    "select role from TripUsers where TripId = "+data.TripId+" AND UserId = "+data.UserId,
+  {type: db.sequelize.QueryTypes.SELECT})
+  .then(function(role) {
+    var newRole = "Unconfirmed";
+    if (role[0].role === "Unconfirmed") {
+      newRole = "Confirmed"
+    }
+    db.sequelize.query(
+      "update TripUsers set role ='"+newRole+"' where TripId = "+data.TripId+" AND UserId = "+data.UserId,
+    {type: db.sequelize.QueryTypes.UPDATE})
+    .then(function(record) {
+      callback(newRole);
+    })
+  })
+}


### PR DESCRIPTION
Allow users to toggle the confirmation status of riders ("Unconfirmed/Rider") for trips where that user is the driver.
